### PR TITLE
Pre part 7

### DIFF
--- a/cloudwatch-logs.tf
+++ b/cloudwatch-logs.tf
@@ -1,29 +1,29 @@
 resource "aws_cloudwatch_log_group" "client" {
-  name = "${local.project_tag}-client-logs"
+  name_prefix = "${local.project_tag}-client-"
 }
 
 resource "aws_cloudwatch_log_group" "client_sidecars" {
-  name = "${local.project_tag}-client-sidecars-logs"
+  name_prefix = "${local.project_tag}-client-sidecars-"
 }
 
 resource "aws_cloudwatch_log_group" "fruits" {
-  name = "${local.project_tag}-fruits-logs"
+  name_prefix = "${local.project_tag}-fruits-"
 }
 
 resource "aws_cloudwatch_log_group" "fruits_sidecars" {
-  name = "${local.project_tag}-fruits-sidecars-logs"
+  name_prefix = "${local.project_tag}-fruits-sidecars-"
 }
 
 resource "aws_cloudwatch_log_group" "vegetables" {
-  name = "${local.project_tag}-vegetables-logs"
+  name_prefix = "${local.project_tag}-vegetables-"
 }
 
 resource "aws_cloudwatch_log_group" "vegetables_sidecars" {
-  name = "${local.project_tag}-vegetables-sidecars-logs"
+  name_prefix = "${local.project_tag}-vegetables-sidecars-"
 }
 
 resource "aws_cloudwatch_log_group" "acl" {
-  name = "${local.project_tag}-acl-logs"
+  name_prefix = "${local.project_tag}-acl-"
 }
 
 locals {

--- a/cloudwatch-logs.tf
+++ b/cloudwatch-logs.tf
@@ -1,29 +1,29 @@
 resource "aws_cloudwatch_log_group" "client" {
-  name = "${var.default_tags.project}-client-logs"
+  name = "${local.project_tag}-client-logs"
 }
 
 resource "aws_cloudwatch_log_group" "client_sidecars" {
-  name = "${var.default_tags.project}-client-sidecars-logs"
+  name = "${local.project_tag}-client-sidecars-logs"
 }
 
 resource "aws_cloudwatch_log_group" "fruits" {
-  name = "${var.default_tags.project}-fruits-logs"
+  name = "${local.project_tag}-fruits-logs"
 }
 
 resource "aws_cloudwatch_log_group" "fruits_sidecars" {
-  name = "${var.default_tags.project}-fruits-sidecars-logs"
+  name = "${local.project_tag}-fruits-sidecars-logs"
 }
 
 resource "aws_cloudwatch_log_group" "vegetables" {
-  name = "${var.default_tags.project}-vegetables-logs"
+  name = "${local.project_tag}-vegetables-logs"
 }
 
 resource "aws_cloudwatch_log_group" "vegetables_sidecars" {
-  name = "${var.default_tags.project}-vegetables-sidecars-logs"
+  name = "${local.project_tag}-vegetables-sidecars-logs"
 }
 
 resource "aws_cloudwatch_log_group" "acl" {
-  name = "${var.default_tags.project}-acl-logs"
+  name = "${local.project_tag}-acl-logs"
 }
 
 locals {
@@ -32,7 +32,7 @@ locals {
     options = {
       awslogs-group         = aws_cloudwatch_log_group.acl.name
       awslogs-region        = var.region
-      awslogs-stream-prefix = "${var.default_tags.project}-acl-"
+      awslogs-stream-prefix = "${local.project_tag}-acl-"
     }
   }
   client_logs_configuration = {
@@ -40,7 +40,7 @@ locals {
     options = {
       awslogs-group         = aws_cloudwatch_log_group.client.name
       awslogs-region        = var.region
-      awslogs-stream-prefix = "${var.default_tags.project}-client"
+      awslogs-stream-prefix = "${local.project_tag}-client"
     }
   }
   client_sidecars_log_configuration = {
@@ -48,7 +48,7 @@ locals {
     options = {
       awslogs-group         = aws_cloudwatch_log_group.client_sidecars.name
       awslogs-region        = var.region
-      awslogs-stream-prefix = "${var.default_tags.project}-client-sidecars-"
+      awslogs-stream-prefix = "${local.project_tag}-client-sidecars-"
     }
   }
   fruits_log_configuration = {
@@ -56,7 +56,7 @@ locals {
     options = {
       awslogs-group         = aws_cloudwatch_log_group.fruits.name
       awslogs-region        = var.region
-      awslogs-stream-prefix = "${var.default_tags.project}-fruits"
+      awslogs-stream-prefix = "${local.project_tag}-fruits"
     }
   }
   fruits_sidecars_log_configuration = {
@@ -64,7 +64,7 @@ locals {
     options = {
       awslogs-group         = aws_cloudwatch_log_group.fruits_sidecars.name
       awslogs-region        = var.region
-      awslogs-stream-prefix = "${var.default_tags.project}-fruits-sidecars-"
+      awslogs-stream-prefix = "${local.project_tag}-fruits-sidecars-"
     }
   }
   vegetables_log_configuration = {
@@ -72,7 +72,7 @@ locals {
     options = {
       awslogs-group         = aws_cloudwatch_log_group.vegetables.name
       awslogs-region        = var.region
-      awslogs-stream-prefix = "${var.default_tags.project}-vegetables"
+      awslogs-stream-prefix = "${local.project_tag}-vegetables"
     }
   }
   vegetables_sidecars_log_configuration = {
@@ -80,7 +80,7 @@ locals {
     options = {
       awslogs-group         = aws_cloudwatch_log_group.vegetables_sidecars.name
       awslogs-region        = var.region
-      awslogs-stream-prefix = "${var.default_tags.project}-vegetables-sidecars-"
+      awslogs-stream-prefix = "${local.project_tag}-vegetables-sidecars-"
     }
   }
 }

--- a/data.tf
+++ b/data.tf
@@ -1,3 +1,9 @@
+# Note: filter out wavelength zones if they're enabled in the account being deployed to.
+# If these aren't filtered out, they'll throw an error when trying to assign an IPv6 CIDR block.
 data "aws_availability_zones" "available" {
   state = "available"
+  filter {
+    name   = "group-name"
+    values = [var.region]
+  }
 }

--- a/ec2.tf
+++ b/ec2.tf
@@ -9,7 +9,7 @@ resource "aws_instance" "database" {
   vpc_security_group_ids = [aws_security_group.database.id]
   private_ip             = var.database_private_ip
   key_name               = var.ec2_key_pair
-  tags                   = { "Name" = "${var.default_tags.project}-database" }
+  tags                   = { "Name" = "${local.project_tag}-database" }
 
   user_data = base64encode(templatefile("${path.module}/scripts/database.sh", {
     DATABASE_SERVICE_NAME = var.database_service_name
@@ -33,7 +33,7 @@ resource "aws_instance" "consul_server" {
 
   iam_instance_profile = aws_iam_instance_profile.consul_instance_profile.name
 
-  tags = { "Name" = "${var.default_tags.project}-consul-server" }
+  tags = { "Name" = "${local.project_tag}-consul-server" }
 
   user_data = base64encode(templatefile("${path.module}/scripts/server.sh", {
     CA_PUBLIC_KEY             = tls_self_signed_cert.ca_cert.cert_pem
@@ -44,7 +44,7 @@ resource "aws_instance" "consul_server" {
     CONSUL_SERVER_COUNT       = var.consul_server_count
     CONSUL_SERVER_DATACENTER  = var.consul_dc1_name
     AUTO_JOIN_TAG             = "Name"
-    AUTO_JOIN_TAG_VALUE       = "${var.default_tags.project}-consul-server"
+    AUTO_JOIN_TAG_VALUE       = "${local.project_tag}-consul-server"
   }))
 
   depends_on = [aws_nat_gateway.nat]

--- a/ec2.tf
+++ b/ec2.tf
@@ -45,6 +45,7 @@ resource "aws_instance" "consul_server" {
     CONSUL_SERVER_DATACENTER  = var.consul_dc1_name
     AUTO_JOIN_TAG             = "Name"
     AUTO_JOIN_TAG_VALUE       = "${local.project_tag}-consul-server"
+    SERVICE_NAME_PREFIX = local.project_tag
   }))
 
   depends_on = [aws_nat_gateway.nat]

--- a/ecs-cluster.tf
+++ b/ecs-cluster.tf
@@ -1,3 +1,3 @@
 resource "aws_ecs_cluster" "main" {
-  name = var.default_tags.project
+  name = local.project_tag
 }

--- a/ecs-loadbalancers.tf
+++ b/ecs-loadbalancers.tf
@@ -7,7 +7,7 @@ resource "aws_lb" "client_alb" {
   idle_timeout       = 60
   ip_address_type    = "dualstack"
 
-  tags = { "Name" = "${var.default_tags.project}-client-alb" }
+  tags = { "Name" = "${local.project_tag}-client-alb" }
 }
 
 # User Facing Client Target Group
@@ -29,7 +29,7 @@ resource "aws_lb_target_group" "client_alb_targets" {
     protocol            = "HTTP"
   }
 
-  tags = { "Name" = "${var.default_tags.project}-client-tg" }
+  tags = { "Name" = "${local.project_tag}-client-tg" }
 }
 
 # User Facing Client ALB Listeners
@@ -54,7 +54,7 @@ resource "aws_lb" "consul_server_alb" {
   idle_timeout       = 60
   ip_address_type    = "dualstack"
 
-  tags = { "Name" = "${var.default_tags.project}-consul-server-alb" }
+  tags = { "Name" = "${local.project_tag}-consul-server-alb" }
 }
 
 # Consul Server Target Group
@@ -76,7 +76,7 @@ resource "aws_lb_target_group" "consul_server_alb_targets" {
     protocol            = "HTTP"
   }
 
-  tags = { "Name" = "${var.default_tags.project}-consul-server-tg" }
+  tags = { "Name" = "${local.project_tag}-consul-server-tg" }
 }
 
 resource "aws_lb_target_group_attachment" "consul_server" {

--- a/ecs-services.tf
+++ b/ecs-services.tf
@@ -1,6 +1,6 @@
 # User Facing Client Service
 resource "aws_ecs_service" "client" {
-  name            = "${var.default_tags.project}-client"
+  name            = "${local.project_tag}-client"
   cluster         = aws_ecs_cluster.main.arn
   task_definition = module.client.task_definition_arn
   desired_count   = 1
@@ -24,7 +24,7 @@ resource "aws_ecs_service" "client" {
 }
 
 resource "aws_ecs_service" "fruits" {
-  name            = "${var.default_tags.project}-fruits"
+  name            = "${local.project_tag}-fruits"
   cluster         = aws_ecs_cluster.main.arn
   task_definition = module.fruits.task_definition_arn
   desired_count   = 3
@@ -42,7 +42,7 @@ resource "aws_ecs_service" "fruits" {
 }
 
 resource "aws_ecs_service" "vegetables" {
-  name            = "${var.default_tags.project}-vegetables"
+  name            = "${local.project_tag}-vegetables"
   cluster         = aws_ecs_cluster.main.arn
   task_definition = module.vegetables.task_definition_arn
   desired_count   = 1
@@ -63,7 +63,7 @@ module "consul_acl_controller" {
   source  = "hashicorp/consul-ecs/aws//modules/acl-controller"
   version = "0.4.1"
 
-  name_prefix     = var.default_tags.project
+  name_prefix     = local.project_tag
   ecs_cluster_arn = aws_ecs_cluster.main.arn
   region          = var.region
 

--- a/ecs-task-definitions.tf
+++ b/ecs-task-definitions.tf
@@ -5,7 +5,7 @@ module "client" {
   source  = "hashicorp/consul-ecs/aws//modules/mesh-task"
   version = "0.4.1"
 
-  family                   = "${var.default_tags.project}-client"
+  family                   = "${local.project_tag}-client"
   requires_compatibilities = ["FARGATE"]
   # required for Fargate launch type
   memory = 512
@@ -46,7 +46,7 @@ module "client" {
 
   # All settings required by the mesh-task module
   acls                           = true
-  acl_secret_name_prefix         = var.default_tags.project
+  acl_secret_name_prefix         = local.project_tag
   consul_datacenter              = var.consul_dc1_name
   consul_server_ca_cert_arn      = aws_secretsmanager_secret.consul_root_ca_cert.arn
   consul_client_token_secret_arn = module.consul_acl_controller.client_token_secret_arn
@@ -70,7 +70,7 @@ module "client" {
       # The "family" will map both to the Consul Service and the ECS Task Definition
       # https://github.com/hashicorp/terraform-aws-consul-ecs/blob/main/modules/mesh-task/main.tf#L187
       # https://github.com/hashicorp/terraform-aws-consul-ecs/blob/v0.3.0/modules/mesh-task/variables.tf#L6-L10
-      destinationName = "${var.default_tags.project}-fruits"
+      destinationName = "${local.project_tag}-fruits"
       # This is the port that requests to this service will be sent to, and, the port that the proxy will be
       # listening on LOCALLY.
       # https://github.com/hashicorp/consul-ecs/blob/0817f073c665c3933e9455f477b18500616e7c47/config/schema.json#L326
@@ -81,7 +81,7 @@ module "client" {
       # https://github.com/hashicorp/consul-ecs/blob/85755adb288055df92c1880d30f1861db771ca63/subcommand/mesh-init/command_test.go#L77
       # looks like upstreams need different local bind ports, which begs the question of what a localBindPort is even doing
       # I guess this is just what the service points to that the envoy listener goes through
-      destinationName = "${var.default_tags.project}-vegetables"
+      destinationName = "${local.project_tag}-vegetables"
       localBindPort   = 1235
     }
   ]
@@ -98,7 +98,7 @@ module "fruits" {
   source  = "hashicorp/consul-ecs/aws//modules/mesh-task"
   version = "0.4.1"
 
-  family                   = "${var.default_tags.project}-fruits"
+  family                   = "${local.project_tag}-fruits"
   requires_compatibilities = ["FARGATE"]
   # required for Fargate launch type
   memory = 512
@@ -138,7 +138,7 @@ module "fruits" {
   ]
 
   acls                           = true
-  acl_secret_name_prefix         = var.default_tags.project
+  acl_secret_name_prefix         = local.project_tag
   consul_datacenter              = var.consul_dc1_name
   consul_server_ca_cert_arn      = aws_secretsmanager_secret.consul_root_ca_cert.arn
   consul_client_token_secret_arn = module.consul_acl_controller.client_token_secret_arn
@@ -167,7 +167,7 @@ module "vegetables" {
   source  = "hashicorp/consul-ecs/aws//modules/mesh-task"
   version = "0.4.1"
 
-  family                   = "${var.default_tags.project}-vegetables"
+  family                   = "${local.project_tag}-vegetables"
   requires_compatibilities = ["FARGATE"]
   # required for Fargate launch type
   memory = 512
@@ -207,7 +207,7 @@ module "vegetables" {
   ]
 
   acls                           = true
-  acl_secret_name_prefix         = var.default_tags.project
+  acl_secret_name_prefix         = local.project_tag
   consul_datacenter              = var.consul_dc1_name
   consul_server_ca_cert_arn      = aws_secretsmanager_secret.consul_root_ca_cert.arn
   consul_client_token_secret_arn = module.consul_acl_controller.client_token_secret_arn

--- a/iam.tf
+++ b/iam.tf
@@ -1,6 +1,6 @@
 # Consul Instance Role
 resource "aws_iam_role" "consul_instance" {
-  name_prefix        = "${var.default_tags.project}-role-"
+  name_prefix        = "${local.project_tag}-role-"
   assume_role_policy = data.aws_iam_policy_document.instance_trust_policy.json
 }
 
@@ -34,13 +34,13 @@ data "aws_iam_policy_document" "instance_permissions_policy" {
 
 ## Consul Instance Role <> Policy Attachment
 resource "aws_iam_role_policy" "consul_instance_policy" {
-  name_prefix = "${var.default_tags.project}-instance-policy-"
+  name_prefix = "${local.project_tag}-instance-policy-"
   role        = aws_iam_role.consul_instance.id
   policy      = data.aws_iam_policy_document.instance_permissions_policy.json
 }
 
 ## Consul Instance Profile <> Role Attachment
 resource "aws_iam_instance_profile" "consul_instance_profile" {
-  name_prefix = "${var.default_tags.project}-instance-profile-"
+  name_prefix = "${local.project_tag}-instance-profile-"
   role        = aws_iam_role.consul_instance.name
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,5 @@
 locals {
+  project_tag = coalesce(terraform.workspace, var.default_tags.project)
   public_cidr_blocks  = [for i in range(var.public_subnet_count) : cidrsubnet(var.vpc_cidr, 4, i)]
   private_cidr_blocks = [for i in range(var.private_subnet_count) : cidrsubnet(var.vpc_cidr, 4, i + var.public_subnet_count)]
   server_private_ips  = [for i in local.private_cidr_blocks : cidrhost(i, 250)]

--- a/locals.tf
+++ b/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  project_tag = coalesce(terraform.workspace, var.default_tags.project)
+  project_tag = terraform.workspace == "default" ? var.default_tags.project : terraform.workspace
   public_cidr_blocks  = [for i in range(var.public_subnet_count) : cidrsubnet(var.vpc_cidr, 4, i)]
   private_cidr_blocks = [for i in range(var.private_subnet_count) : cidrsubnet(var.vpc_cidr, 4, i + var.public_subnet_count)]
   server_private_ips  = [for i in local.private_cidr_blocks : cidrhost(i, 250)]

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 4.15.1"
     }
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,3 +13,8 @@ output "consul_server_endpoint" {
   description = "The ALB endpoint for the Consul Servers."
   value       = aws_lb.consul_server_alb.dns_name
 }
+
+output "project_tag" {
+  description = "the tag used on all deployed resources and also as the service prefix"
+  value = local.project_tag
+}

--- a/scripts/server.sh
+++ b/scripts/server.sh
@@ -78,6 +78,38 @@ ports {
   https = 8501
 }
 
+# Extra configurations to load up on bootstrap.  We're going to create intentions instead of having to do it via UI.
+config_entries {
+  bootstrap = [
+    {
+      kind = "proxy-defaults"
+      name = "global"
+      config {
+        protocol = "http"
+      }
+    },
+    {
+      Kind = "service-intentions"
+      Name = "${SERVICE_NAME_PREFIX}-fruits"
+      Sources = [
+        {
+          Name = "${SERVICE_NAME_PREFIX}-client"
+          Action = "allow"
+        }
+      ]
+    },
+    {
+      Kind = "service-intentions"
+      Name = "${SERVICE_NAME_PREFIX}-vegetables"
+      Sources = [
+        {
+          Name = "${SERVICE_NAME_PREFIX}-client"
+          Action = "allow"
+        }
+      ]
+    }
+  ]
+}
 EOF
 
 # Start Consul

--- a/secrets-manager.tf
+++ b/secrets-manager.tf
@@ -1,5 +1,5 @@
 resource "aws_secretsmanager_secret" "consul_gossip_key" {
-  name_prefix = "${var.default_tags.project}-gossip-key-"
+  name_prefix = "${local.project_tag}-gossip-key-"
 }
 
 resource "aws_secretsmanager_secret_version" "consul_gossip_key" {
@@ -8,7 +8,7 @@ resource "aws_secretsmanager_secret_version" "consul_gossip_key" {
 }
 
 resource "aws_secretsmanager_secret" "consul_bootstrap_token" {
-  name_prefix = "${var.default_tags.project}-bootstrap-token-"
+  name_prefix = "${local.project_tag}-bootstrap-token-"
 }
 
 resource "aws_secretsmanager_secret_version" "consul_bootstrap_token" {
@@ -17,7 +17,7 @@ resource "aws_secretsmanager_secret_version" "consul_bootstrap_token" {
 }
 
 resource "aws_secretsmanager_secret" "consul_root_ca_cert" {
-  name_prefix = "${var.default_tags.project}-root-ca-cert-"
+  name_prefix = "${local.project_tag}-root-ca-cert-"
 }
 
 resource "aws_secretsmanager_secret_version" "consul_root_ca_cert" {

--- a/security-groups.tf
+++ b/security-groups.tf
@@ -1,6 +1,6 @@
 # Security Group for Client ALB
 resource "aws_security_group" "client_alb" {
-  name_prefix = "${var.default_tags.project}-ecs-client-alb"
+  name_prefix = "${local.project_tag}-ecs-client-alb"
   description = "security group for client service application load balancer"
   vpc_id      = aws_vpc.main.id
 }
@@ -29,7 +29,7 @@ resource "aws_security_group_rule" "client_alb_allow_outbound" {
 
 # Security Group for ECS Client Service.
 resource "aws_security_group" "ecs_client_service" {
-  name_prefix = "${var.default_tags.project}-ecs-client-service"
+  name_prefix = "${local.project_tag}-ecs-client-service"
   description = "ECS Client service security group."
   vpc_id      = aws_vpc.main.id
 }
@@ -66,7 +66,7 @@ resource "aws_security_group_rule" "ecs_client_service_allow_outbound" {
 }
 
 resource "aws_security_group" "ecs_fruits_service" {
-  name_prefix = "${var.default_tags.project}-ecs-fruits-service"
+  name_prefix = "${local.project_tag}-ecs-fruits-service"
   description = "ECS Fruits service security group."
   vpc_id      = aws_vpc.main.id
 }
@@ -93,7 +93,7 @@ resource "aws_security_group_rule" "ecs_fruits_service_allow_outbound" {
 }
 
 resource "aws_security_group" "ecs_vegetables_service" {
-  name_prefix = "${var.default_tags.project}-ecs-vegetables-service"
+  name_prefix = "${local.project_tag}-ecs-vegetables-service"
   description = "ECS Vegetables service security group."
   vpc_id      = aws_vpc.main.id
 }
@@ -121,7 +121,7 @@ resource "aws_security_group_rule" "ecs_vegetables_service_allow_outbound" {
 
 # Security Group for Database Server
 resource "aws_security_group" "database" {
-  name_prefix = "${var.default_tags.project}-database"
+  name_prefix = "${local.project_tag}-database"
   description = "Database security group."
   vpc_id      = aws_vpc.main.id
 }
@@ -158,7 +158,7 @@ resource "aws_security_group_rule" "database_allow_outbound" {
 }
 
 resource "aws_security_group" "consul_server" {
-  name_prefix = "${var.default_tags.project}-consul-server"
+  name_prefix = "${local.project_tag}-consul-server"
   description = "Security Group for the Consul servers"
   vpc_id      = aws_vpc.main.id
 }
@@ -267,7 +267,7 @@ resource "aws_security_group_rule" "consul_server_allow_client_8501" {
 
 # Consul Server ALB Security Group
 resource "aws_security_group" "consul_server_alb" {
-  name_prefix = "${var.default_tags.project}-consul-server-alb"
+  name_prefix = "${local.project_tag}-consul-server-alb"
   description = "Security Group for the ALB fronting the consul server"
   vpc_id      = aws_vpc.main.id
 }
@@ -294,7 +294,7 @@ resource "aws_security_group_rule" "consul_server_alb_allow_outbound" {
 }
 
 resource "aws_security_group" "acl_controller" {
-  name_prefix = "${var.default_tags.project}-acl-controller-"
+  name_prefix = "${local.project_tag}-acl-controller-"
   description = "Consul ACL Controller service security group."
   vpc_id      = aws_vpc.main.id
 }
@@ -322,7 +322,7 @@ resource "aws_security_group_rule" "acl_controller_allow_outbound" {
 
 # A Generalized group for all consul clients
 resource "aws_security_group" "consul_client" {
-  name_prefix = "${var.default_tags.project}-consul-client-"
+  name_prefix = "${local.project_tag}-consul-client-"
   description = "General security group for consul clients."
   vpc_id      = aws_vpc.main.id
 }

--- a/tls.tf
+++ b/tls.tf
@@ -6,7 +6,6 @@ resource "tls_private_key" "ca_key" {
 
 # Root Public Certificate
 resource "tls_self_signed_cert" "ca_cert" {
-  key_algorithm     = tls_private_key.ca_key.algorithm
   private_key_pem   = tls_private_key.ca_key.private_key_pem
   is_ca_certificate = true
 
@@ -32,7 +31,6 @@ resource "tls_private_key" "consul_server_key" {
 
 ## Consul Server Cert
 resource "tls_cert_request" "consul_server_cert" {
-  key_algorithm   = tls_private_key.consul_server_key.algorithm
   private_key_pem = tls_private_key.consul_server_key.private_key_pem
 
   subject {
@@ -54,7 +52,6 @@ resource "tls_locally_signed_cert" "consul_server_signed_cert" {
   cert_request_pem = tls_cert_request.consul_server_cert.cert_request_pem
 
   ca_private_key_pem = tls_private_key.ca_key.private_key_pem
-  ca_key_algorithm   = tls_private_key.ca_key.algorithm
   ca_cert_pem        = tls_self_signed_cert.ca_cert.cert_pem
 
   allowed_uses = [

--- a/variables.tf
+++ b/variables.tf
@@ -34,6 +34,7 @@ variable "private_subnet_count" {
 variable "database_private_ip" {
   type        = string
   description = "Private ip address of database"
+  default = "10.255.3.253"
 }
 
 variable "ec2_key_pair" {

--- a/variables.tf
+++ b/variables.tf
@@ -33,8 +33,8 @@ variable "private_subnet_count" {
 
 variable "database_private_ip" {
   type        = string
-  description = "Private ip address of database"
-  default = "10.255.3.253"
+  description = "Private ip address of database. Make sure the IP is within the range of the vpc_cidr variable."
+  default = "10.255.2.253"
 }
 
 variable "ec2_key_pair" {

--- a/vpc.tf
+++ b/vpc.tf
@@ -2,7 +2,7 @@
 resource "aws_vpc" "main" {
   cidr_block = var.vpc_cidr
   tags = {
-    "Name" = "${var.default_tags.project}-vpc"
+    "Name" = "${local.project_tag}-vpc"
   }
   assign_generated_ipv6_cidr_block = true
   instance_tenancy                 = "default"
@@ -20,7 +20,7 @@ resource "aws_subnet" "public" {
   map_public_ip_on_launch         = true
   assign_ipv6_address_on_creation = true
   tags = {
-    "Name" = "${var.default_tags.project}-public-${data.aws_availability_zones.available.names[count.index]}"
+    "Name" = "${local.project_tag}-public-${data.aws_availability_zones.available.names[count.index]}"
   }
   availability_zone = data.aws_availability_zones.available.names[count.index]
 }
@@ -29,7 +29,7 @@ resource "aws_subnet" "public" {
 resource "aws_route_table" "public" {
   vpc_id = aws_vpc.main.id
   tags = {
-    "Name" = "${var.default_tags.project}-public-route-table"
+    "Name" = "${local.project_tag}-public-route-table"
   }
 }
 
@@ -38,7 +38,7 @@ resource "aws_internet_gateway" "gw" {
   vpc_id = aws_vpc.main.id
 
   tags = {
-    Name = "${var.default_tags.project}-internet-gateway"
+    Name = "${local.project_tag}-internet-gateway"
   }
 }
 
@@ -63,7 +63,7 @@ resource "aws_subnet" "private" {
   # 10.255.0.0/20 -> 10.255.0.0/24
   cidr_block = local.private_cidr_blocks[count.index]
   tags = {
-    "Name" = "${var.default_tags.project}-private-${data.aws_availability_zones.available.names[count.index]}"
+    "Name" = "${local.project_tag}-private-${data.aws_availability_zones.available.names[count.index]}"
   }
   availability_zone = data.aws_availability_zones.available.names[count.index]
 }
@@ -72,7 +72,7 @@ resource "aws_subnet" "private" {
 resource "aws_route_table" "private" {
   vpc_id = aws_vpc.main.id
   tags = {
-    "Name" = "${var.default_tags.project}-private-route-table"
+    "Name" = "${local.project_tag}-private-route-table"
   }
 }
 
@@ -80,7 +80,7 @@ resource "aws_route_table" "private" {
 resource "aws_eip" "nat" {
   vpc = true
   tags = {
-    "Name" = "${var.default_tags.project}-nat-eip"
+    "Name" = "${local.project_tag}-nat-eip"
   }
 }
 
@@ -90,7 +90,7 @@ resource "aws_nat_gateway" "nat" {
   subnet_id     = aws_subnet.public.0.id
 
   tags = {
-    "Name" = "${var.default_tags.project}-nat"
+    "Name" = "${local.project_tag}-nat"
   }
 
   # To ensure proper ordering, it is recommended to add an explicit dependency


### PR DESCRIPTION
A handful of commits to prepare for part 7.  PR'ing so that we have some ease of visibility:

1. Created a local for the "project" tag we've been using to switch based on if a Terraform Workspace exists.  This will help for TFC.

2. Swapped out values to use the local created in point number 1

3. Filtered out wavelength availability zones.  They'll throw an error for accounts that have them enabled since they don't work with IPv6.

4. Changed cloudwatch logs to use `name_prefix` instead of name to avoid naming conflicts (i.e. same project used for multiple workspaces.)

5. Set a default value for the database IP and also a description to keep it within the VPC's CIDR

6. Added consul config entries to setup service intentions for us on boot up so that we don't have to manually create them in the UI.