### PR TITLE
Enable Consul and DB to run when instance restarts

### DIFF
--- a/scripts/database.sh
+++ b/scripts/database.sh
@@ -27,3 +27,6 @@ EOF
 # Reload unit files and start the database service
 systemctl daemon-reload
 systemctl start database
+
+# Enable the DB daemon to start on instance restart
+systemctl enable database

--- a/scripts/server.sh
+++ b/scripts/server.sh
@@ -1,24 +1,29 @@
 #!/bin/bash
 
+CA_PUBLIC_KEY_LOCATION="/etc/consul.d/certs/consul-agent-ca.pem"
+CONSUL_SERVER_PUBLIC_KEY_LOCATION="/etc/consul.d/certs/consul-server-cert.pem"
+CONSUL_SERVER_PRIVATE_KEY_LOCATION="/etc/consul.d/certs/consul-server-key.pem"
+CONSUL_VERSION="1.11.4"
+
 # Install Consul.  This verifies the download via GPG and then creates...
 # 1 - a default /etc/consul.d/consul.hcl
 # 2 - a default systemd consul.service file
 curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add -
 apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
-apt update && apt install -y consul=1.11.4
+apt update && apt install -y consul=$${CONSUL_VERSION}
 
 # Make directory for certs
 mkdir /etc/consul.d/certs
 
-cat > /etc/consul.d/certs/consul-agent-ca.pem <<- EOF
+cat > $${CA_PUBLIC_KEY_LOCATION} <<- EOF
 ${CA_PUBLIC_KEY}
 EOF
 
-cat > /etc/consul.d/certs/consul-server-cert.pem <<- EOF
+cat > $${CONSUL_SERVER_PUBLIC_KEY_LOCATION} <<- EOF
 ${CONSUL_SERVER_PUBLIC_KEY}
 EOF
 
-cat > /etc/consul.d/certs/consul-server-key.pem <<- EOF
+cat > $${CONSUL_SERVER_PRIVATE_KEY_LOCATION} <<- EOF
 ${CONSUL_SERVER_PRIVATE_KEY}
 EOF
 
@@ -44,9 +49,9 @@ client_addr = "0.0.0.0"
 # number of servers to wait for until bootstrapping
 bootstrap_expect=${CONSUL_SERVER_COUNT}
 # root certificate authority public cert to verify signatures
-ca_file = "/etc/consul.d/certs/consul-agent-ca.pem"
+ca_file = $${CA_PUBLIC_KEY_LOCATION}
 # public certificate of the server
-cert_file = "/etc/consul.d/certs/consul-server-cert.pem"
+cert_file = $${CONSUL_SERVER_PUBLIC_KEY_LOCATION}
 # enable "Connect" which is Consul's Service Mesh
 connect {
   enabled = true
@@ -114,3 +119,6 @@ EOF
 
 # Start Consul
 systemctl start consul
+
+# Enable Consul to start on instance restart
+systemctl enable consul

--- a/scripts/server.sh
+++ b/scripts/server.sh
@@ -63,7 +63,7 @@ data_dir = "/opt/consul"
 # the 32byte key for Gossip encryption - uses AES Galois/Counter Mode (GCM)
 encrypt = "${CONSUL_GOSSIP_KEY}"
 # private key for the server
-key_file = "/etc/consul.d/certs/consul-server-key.pem"
+key_file = $${CONSUL_SERVER_PRIVATE_KEY_LOCATION}
 # how the consul nodes will go about joining each other
 retry_join = ["provider=aws tag_key=\"${AUTO_JOIN_TAG}\" tag_value=\"${AUTO_JOIN_TAG_VALUE}\""]
 # whether this consul agent is a server or client


### PR DESCRIPTION
This code should add additional resiliency to the DB and Consul instances as it adds a line:
```
systemctl enable <daemon-name>
```
which will enable it to run automatically after instance boots up. 

Code related to the addition of environment variables in `server.sh` script is just a convenience as it will allow changing the paths to certificates and keys in one place. The `CONSUL_VERSION ` environment variable can also be templated if needed later but this way it will be changed at the top of the file and used by `apt`.